### PR TITLE
Add ability to parse flags field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install requests==2.21.0 pytz==2019.1 mock pytest
+            pip install aiohttp==3.5.4 requests==2.21.0 pytz==2019.1 pytest-asyncio==0.10.0 aioresponses==0.6.0 mock==3.0.5 pytest==5.0.1
       - run:
           command: |
             . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Before you start using this library, you need to get your API key
 All classes are fully annotated, source code it's your best doc : )
 
 ```python
-from darksky.api import DarkSky
+from darksky.api import DarkSky, DarkSkyAsync
 from darksky.types import languages, units, weather
 
 
 API_KEY = '0123456789abcdef9876543210fedcba'
 
+# Synchronous way
 darksky = DarkSky(API_KEY)
 
 latitude = 42.3601
@@ -42,6 +43,25 @@ forecast = darksky.get_forecast(
     exclude=[weather.MINUTELY, weather.ALERTS] # default `[]`
 )
 
+# Asynchronous way
+# NOTE! On Mac os you will have problem with ssl checking https://github.com/aio-libs/aiohttp/issues/2822
+# So you need to create your own session with disabled ssl verify and pass it into the DarkSkyAsync
+# session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))
+# darksky = DarkSkyAsync(API_KEY, client_session=session)
+
+darksky = DarkSkyAsync(API_KEY)
+
+latitude = 42.3601
+longitude = -71.0589
+forecast = await darksky.get_forecast(
+    latitude, longitude,
+    extend=False, # default `False`
+    lang=languages.ENGLISH, # default `ENGLISH`
+    units=units.AUTO, # default `auto`
+    exclude=[weather.MINUTELY, weather.ALERTS] # default `[]`
+)
+
+# Final wrapper identical for both ways
 forecast.latitude # 42.3601
 forecast.longitude # -71.0589
 forecast.timezone # timezone for coordinates. For exmaple: `America/New_York`
@@ -51,9 +71,6 @@ forecast.minutely # MinutelyForecast. Can be found at darksky/forecast.py
 forecast.hourly # HourlyForecast. Can be found at darksky/forecast.py
 forecast.daily # DailyForecast. Can be found at darksky/forecast.py
 forecast.alerts # [Alert]. Can be found at darksky/forecast.py
-
-# Forecast updating
-forecast.refresh()
 ```
 
 ### Contact us.

--- a/darksky/forecast.py
+++ b/darksky/forecast.py
@@ -137,8 +137,7 @@ class Forecast(object):
 
     def __init__(self, latitude: float, longitude: float, timezone: str,
         currently: dict={}, minutely: dict={}, hourly: dict={},
-        daily: dict={}, alerts: [dict]=None, flags: [str]=None, offset: int=None, 
-        refresh_data=None):
+        daily: dict={}, alerts: [dict]=None, flags: [str]=None, offset: int=None):
         self.latitude = latitude
         self.longitude = longitude
         self.timezone = timezone
@@ -156,10 +155,3 @@ class Forecast(object):
             )
 
         self.offset = offset
-
-        self.refresh_data = refresh_data
-    
-    def refresh(self):
-        forecast = self.refresh_data['func'](**self.refresh_data['kwargs'])
-        for field in self.__class__.__annotations__:
-            setattr(self, field, getattr(forecast, field))

--- a/darksky/request_manager.py
+++ b/darksky/request_manager.py
@@ -1,0 +1,43 @@
+import requests
+import aiohttp
+from .exceptions import DarkSkyException
+
+
+class BaseRequestManger(object):
+    def __init__(self, gzip: bool):
+        self.headers = {} if not gzip else {'Accept-Encoding': 'gzip'}
+
+    def make_request(self, url: str, **params):
+        raise NotImplementedError
+
+
+class RequestManger(BaseRequestManger):
+    def __init__(self, gzip: bool):
+        super().__init__(gzip)
+        self.session = requests.Session()
+        self.session.headers = self.headers
+
+    def make_request(self, url: str, **params):
+        response = self.session.get(url, params=params).json()
+        if 'error' in response:
+            raise DarkSkyException(response['code'], response['error'])
+        return response
+
+
+class RequestMangerAsync(BaseRequestManger):
+    def __init__(self, gzip: bool, client_session: aiohttp.ClientSession = None):
+        super().__init__(gzip)
+        assert isinstance(client_session, aiohttp.ClientSession) or client_session is None
+        self.session = aiohttp.ClientSession() if client_session is None else client_session
+
+    async def make_request(self, url: str, **params):
+        # Fix for yarl(Doesn't support any types besides str)
+        for key in params.copy():
+            if params[key] is None:
+                del params[key]
+            
+        async with self.session.get(url, params=params, headers=self.headers) as resp:
+            response = await resp.json()
+            if 'error' in response:
+                raise DarkSkyException(response['code'], response['error'])
+        return response

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md')) as f:
     README = f.read()
@@ -14,7 +14,8 @@ setup(
 
     install_requires=[
         'requests==2.21.0',
-        'pytz==2019.1'
+        'pytz==2019.1',
+        'aiohttp==3.5.4'
     ],
 
     description='The Dark Sky API wrapper',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     ],
 
     description='The Dark Sky API wrapper',
-    long_description=README,
+    long_description='View on github',
 
     author='Detrous',
     author_email='detrous@protonmail.com',

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -41,18 +41,6 @@ def test_forecast_currently():
         assert getattr(forecast_item, forecast_key) == data_item[key]
 
 
-def test_forecast_currently_refresh():
-    forecast = get_forecast()
-
-    forecast_item, data_item = forecast.currently, copy.deepcopy(DATA['currently'])
-    for key in data_item:
-        forecast_key = utils.snake_case_key(key)
-        if isinstance(getattr(forecast_item, forecast_key), datetime):
-            data_item[key] = get_datetime_from_unix(data_item[key])
-        assert hasattr(forecast_item, forecast_key)
-        assert getattr(forecast_item, forecast_key) == data_item[key]
-
-
 def test_forecast_minutely():
     forecast = get_forecast()
 


### PR DESCRIPTION
Current implementation does not make flags field available.
When units is `auto` flags field provides the actual units used in the response, so it is quite important to the data handling.
The `nearest__station` is a bit of a hack, but `nearest-station` is not a valid python identifier name, so... if you have any better idea, please let me know! :D